### PR TITLE
Enable dark them, with keybindings to switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+stlviewer

--- a/README
+++ b/README
@@ -27,4 +27,6 @@ z : Zoom in
 x : Zoom out
 w : wiremesh mode
 r : Reset the view 
+b : Set bright background
+d : Set dark background
 Use the mouse with the left button down to rotate the object

--- a/README
+++ b/README
@@ -27,6 +27,5 @@ z : Zoom in
 x : Zoom out
 w : wiremesh mode
 r : Reset the view 
-b : Set bright background
-d : Set dark background
+t : Toggle dark/bright theme
 Use the mouse with the left button down to rotate the object

--- a/compile.py
+++ b/compile.py
@@ -28,16 +28,16 @@ defines = map(lambda define: "-D" + define, defines)
 defines_str = ' '.join(defines) 
 
 if system_name == "Darwin":
-	frameworks = ['GLUT', 'OpenGL']
-        frameworks = map(lambda framework: "-framework " + framework, frameworks)
-	framework_str =  ' '.join(frameworks)
+    frameworks = ['GLUT', 'OpenGL']
+    frameworks = map(lambda framework: "-framework " + framework, frameworks)
+    framework_str =  ' '.join(frameworks)
 
 if system_name == "Linux":
-	compile_cmd = "gcc -Wall -o %s %s %s %s %s" % (program, files_str, include_str, defines_str, libraries_str)
+    compile_cmd = "gcc -Wall -o %s %s %s %s %s" % (program, files_str, include_str, defines_str, libraries_str)
 elif system_name == "Darwin":
-	compile_cmd = "cc -g -Wall -Wno-deprecated -o %s %s %s %s" % (program, files_str, defines_str, framework_str)
+    compile_cmd = "cc -g -Wall -Wno-deprecated -o %s %s %s %s" % (program, files_str, defines_str, framework_str)
 
 
-print compile_cmd
+print(compile_cmd)
 output = os.system(compile_cmd)
 sys.exit(0)

--- a/stl_viewer.c
+++ b/stl_viewer.c
@@ -342,7 +342,7 @@ init(char *filename)
 	glEnable(GL_DEPTH_TEST);
 	glShadeModel(GL_SMOOTH);
 
-        glClearColor(135.0 / 255, 206.0 / 255.0, 250.0 / 255.0, 0.0);
+        glClearColor(0.0 / 255, 0.0 / 255.0, 0.0 / 255.0, 0.0);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	glColor3f(120.0 / 255.0 , 120.0 / 255.0, 120.0 / 255.0);
 

--- a/stl_viewer.c
+++ b/stl_viewer.c
@@ -55,6 +55,9 @@
 #define MAX_Z_ORTHO_FACTOR 20
 #define ROTATION_FACTOR 15
 
+#define DARK_BG 0, 0, 0, 0
+#define BRIGHT_BG 135.0/255.0, 206.0/255.0, 250.0/255.0, 0.0
+
 static int rotating = 0;
 static int wiremesh = 0;
 static GLfloat scale = DEFAULT_SCALE;
@@ -142,6 +145,14 @@ keyboardFunc(unsigned char key, int x, int y)
                         trackball(rot_cur_quat, 0.0, 0.0, 0.0, 0.0);
                         zoom = DEFAULT_ZOOM;
                         break;
+		case 'd':
+		case 'D':
+			glClearColor(DARK_BG);
+			break;
+		case 'b':
+		case 'B':
+			glClearColor(BRIGHT_BG);
+			break;
 		case 'q':
                 case 'Q':
 			exit(0);

--- a/stl_viewer.c
+++ b/stl_viewer.c
@@ -64,6 +64,7 @@ static GLfloat scale = DEFAULT_SCALE;
 static stl_t *stl;
 static float ortho_factor = 1.5;
 static float zoom = DEFAULT_ZOOM;
+static int dark_theme = 0;
 
 static int screen_width = 0;
 static int screen_height = 0;
@@ -117,6 +118,15 @@ mouse_click(int button, int state, int x, int y)
         }
 }
 
+static void toggle_dark_bg() {
+	if (dark_theme) {
+		glClearColor(DARK_BG);
+	} else {
+		glClearColor(BRIGHT_BG);
+	}
+	dark_theme = 1 - dark_theme;
+}
+
 static void
 keyboardFunc(unsigned char key, int x, int y)
 {
@@ -145,13 +155,9 @@ keyboardFunc(unsigned char key, int x, int y)
                         trackball(rot_cur_quat, 0.0, 0.0, 0.0, 0.0);
                         zoom = DEFAULT_ZOOM;
                         break;
-		case 'd':
-		case 'D':
-			glClearColor(DARK_BG);
-			break;
-		case 'b':
-		case 'B':
-			glClearColor(BRIGHT_BG);
+		case 't':
+		case 'T':
+			toggle_dark_bg();
 			break;
 		case 'q':
                 case 'Q':
@@ -181,6 +187,8 @@ ortho_dimensions(GLfloat *min_x, GLfloat *max_x,
 	*min_z = stl_min_z(stl) - MAX_Z_ORTHO_FACTOR * ortho_factor*max_diff;
 	*max_z = stl_max_z(stl) + MAX_Z_ORTHO_FACTOR * ortho_factor*max_diff;
 }
+
+
 
 static void
 reshape(int width, int height)


### PR DESCRIPTION
Use `b` for bright and `d` for dark theme. A minor usability improvement that I felt lacking. 